### PR TITLE
feat(core): add dividend support to schema and etl pipeline

### DIFF
--- a/src/core/domain_models.py
+++ b/src/core/domain_models.py
@@ -18,6 +18,7 @@ STOCK_PRICE_SCHEMA = {
     "close": pl.Float64,
     "adj_close": pl.Float64,
     "volume": pl.Int64,
+    "dividend": pl.Float64,
 }
 
 
@@ -47,12 +48,14 @@ class StockPrice(BaseModel):
 
     ticker: str
     date: date
+    currency: str
     open: float
     high: float
     low: float
     close: float
     adj_close: float
     volume: int
+    dividend: float = 0.0
 
 
 class FinancialReport(BaseModel):

--- a/src/core/mapper.py
+++ b/src/core/mapper.py
@@ -41,6 +41,12 @@ def map_prices_to_df(pdf: pd.DataFrame, ticker: str, currency: str) -> pl.DataFr
         pl.col("date").cast(pl.Date),
     )
 
+    if "dividends" in prices.columns:
+        prices = prices.rename({"dividends": "dividend"})
+    else:
+        prices = prices.with_columns(pl.lit(0.0).alias("dividend"))
+    prices = prices.with_columns(pl.col("dividend").fill_null(0.0))
+
     # Ensure Date column exists (might be named differently)
     if "date" not in prices.columns and "index" in prices.columns:
         prices = prices.rename({"index": "date"})

--- a/src/etl/extract.py
+++ b/src/etl/extract.py
@@ -68,6 +68,7 @@ class DataExtractor:
                 start=start_date,
                 progress=False,
                 auto_adjust=True,
+                actions=True,
             )
 
             if price_data.empty:


### PR DESCRIPTION
- Update  model and Parquet schema to include  column.
- Enable  in yfinance extraction to fetch historical dividend payments.
- Update mapper to handle dividend column normalization and zero-filling.
- Refactor ETL pipeline to persist dividend data for future yield analysis.

Closes #W13