### PR TITLE
feat(data-mgmt): add snapshot archiver and centralized config Closes #15

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: [pydantic>=2.0.0, pydantic-settings>=2.0.0, polars>=0.20.0]
+        additional_dependencies: [pydantic>=2.0.0, pydantic-settings>=2.0.0, polars>=0.20.0, types-PyYAML>=6.0.0]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: pc etl snapshot restore test help
+
+help:
+	@echo "Available commands:"
+	@echo "  make pc         - Run pre-commit checks"
+	@echo "  make etl        - Run ETL pipeline"
+	@echo "  make snapshot   - Create data snapshots"
+	@echo "  make test       - Run tests"
+
+pc:
+	uv run --extra dev pre-commit run --all-files
+
+etl:
+	uv run qc etl
+
+snapshot:
+	uv run qc snapshot
+
+test:
+	uv run --extra dev pytest

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,41 @@
+universe:
+  stocks:
+    # US Stocks
+    - MSFT
+    - SPGI
+    - GOOG
+    - TMO
+    - V
+    # European Stocks
+    - MUV2.DE
+    - SY1.DE
+    - UNA.AS
+    - ASML.AS
+    - ROG.SW
+    - NOVO-B.CO
+    - ATCO-A.ST
+    - SU.PA
+    - MC.PA
+    - AI.PA
+    # Asian Stocks
+    - 8001.T
+
+  price_only:
+    # Currencies & Crypto
+    - EURUSD=X
+    - CHFEUR=X
+    - DKKEUR=X
+    - SEKEUR=X
+    - JPYEUR=X
+    - BTC-EUR
+    # ETFs (via Xetra in EUR)
+    - EUNL.DE  # iShares Core MSCI World
+    - M7U.DE
+    - EUNM.DE  # iShares MSCI EM (Acc)
+    - AEME.PA  # Amundi MSCI EM
+    - EXSB.DE  # iShares STOXX Europe Small 200
+
+settings:
+  base_dir: "data/prod"
+  archive_dir: "data/archive"
+  initial_price_start_date: "2021-01-01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "plotly>=5.18.0",
     "yfinance>=0.2.35",
     "loguru>=0.7.3",
+    "pyyaml>=6.0.3",
 ]
 
 [project.optional-dependencies]
@@ -20,6 +21,7 @@ dev = [
     "mypy>=1.8.0",
     "pytest>=7.4.0",
     "pydantic-settings>=2.0.0",
+    "types-PyYAML>=6.0.0",
 ]
 
 [build-system]
@@ -50,4 +52,4 @@ python_files = "test_*.py"
 python_functions = "test_*"
 
 [project.scripts]
-etl = "src.main:main"
+qc = "src.main:main"

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration management module."""

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,0 +1,75 @@
+"""Configuration management for Quality Core.
+
+Centralizes all application settings and ticker universe definitions.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from loguru import logger
+from pydantic import BaseModel, Field
+
+
+class UniverseConfig(BaseModel):
+    """Ticker universe configuration."""
+
+    stocks: list[str] = Field(description="Tickers with fundamental data")
+    price_only: list[str] = Field(description="Tickers with price data only (FX, ETFs, indices)")
+
+    @property
+    def all_tickers(self) -> list[str]:
+        """Return all tickers (stocks + price-only assets)."""
+        return self.stocks + self.price_only
+
+
+class AppSettings(BaseModel):
+    """Application-level settings."""
+
+    base_dir: Path = Field(default=Path("data/prod"))
+    archive_dir: Path = Field(default=Path("data/archive"))
+    initial_price_start_date: str = Field(default="2021-01-01")
+
+    @property
+    def prices_dir(self) -> Path:
+        """Directory for price data."""
+        return self.base_dir / "prices"
+
+    @property
+    def fundamentals_dir(self) -> Path:
+        """Directory for fundamental data."""
+        return self.base_dir / "fundamentals"
+
+
+class Config(BaseModel):
+    """Root configuration model."""
+
+    universe: UniverseConfig
+    settings: AppSettings
+
+
+def load_config(config_path: Path = Path("config.yaml")) -> Config:
+    """Load configuration from YAML file.
+
+    Args:
+        config_path: Path to config.yaml file
+
+    Returns:
+        Parsed configuration object
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist
+        yaml.YAMLError: If config file is malformed
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    logger.info(f"Loading configuration from {config_path}")
+
+    with config_path.open("r") as f:
+        raw_config: dict[str, Any] = yaml.safe_load(f)
+
+    config = Config(**raw_config)
+    logger.debug(f"Loaded {len(config.universe.all_tickers)} tickers from config")
+
+    return config

--- a/src/data_mgmt/__init__.py
+++ b/src/data_mgmt/__init__.py
@@ -1,0 +1,1 @@
+"""Data management utilities for backup and restoration."""

--- a/src/data_mgmt/archiver.py
+++ b/src/data_mgmt/archiver.py
@@ -1,0 +1,145 @@
+"""Data archiving and snapshot management.
+
+Provides compressed monolithic snapshots of parquet data for:
+- Backup and disaster recovery
+- High-performance batch analysis
+- Data versioning and reproducibility
+"""
+
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+from loguru import logger
+
+
+class DataArchiver:
+    """Manages creation and restoration of compressed data snapshots."""
+
+    def __init__(self, base_dir: Path, archive_dir: Path) -> None:
+        """Initialize archiver with data and archive directories.
+
+        Args:
+            base_dir: Root directory containing prices/ and fundamentals/
+            archive_dir: Directory for storing snapshot archives
+        """
+        self.base_dir = Path(base_dir)
+        self.archive_dir = Path(archive_dir)
+        self.archive_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"DataArchiver initialized (archive: {self.archive_dir})")
+
+    def create_snapshot(self, data_type: str) -> Path:
+        """Create compressed monolithic snapshot of all parquet files.
+
+        Optimization: Casts low-cardinality columns to Categorical to reduce memory.
+
+        Args:
+            data_type: Type of data ("prices" or "fundamentals")
+
+        Returns:
+            Path to created snapshot file
+
+        Raises:
+            ValueError: If data_type is invalid or no data found
+        """
+        if data_type not in ("prices", "fundamentals"):
+            raise ValueError(f"Invalid data_type: {data_type}. Must be 'prices' or 'fundamentals'")
+
+        source_dir = self.base_dir / data_type
+        if not source_dir.exists():
+            raise ValueError(f"Source directory does not exist: {source_dir}")
+
+        pattern = str(source_dir / "*.parquet")
+        logger.info(f"Creating {data_type} snapshot from {pattern}")
+
+        # Read all parquet files in one go
+        data = pl.read_parquet(pattern)
+
+        if data.is_empty():
+            raise ValueError(f"No data found in {source_dir}")
+
+        # Optimize memory: Cast low-cardinality columns to Categorical
+        categorical_cols = ["ticker", "currency"]
+        if data_type == "fundamentals":
+            categorical_cols.append("period_type")
+
+        for col in categorical_cols:
+            if col in data.columns:
+                data = data.with_columns(pl.col(col).cast(pl.Categorical))
+
+        # Generate snapshot filename with current date
+        snapshot_date = date.today().isoformat()
+        snapshot_filename = f"{data_type}_snapshot_{snapshot_date}.parquet"
+        snapshot_path = self.archive_dir / snapshot_filename
+
+        # Write with compression
+        data.write_parquet(snapshot_path, compression="zstd")
+
+        logger.success(
+            f"Created snapshot: {snapshot_path} ({len(data):,} rows, "
+            f"{snapshot_path.stat().st_size / 1024 / 1024:.2f} MB)"
+        )
+
+        return snapshot_path
+
+    def restore_snapshot(self, snapshot_path: Path, target_dir: Path) -> None:
+        """Restore snapshot by splitting into individual ticker files.
+
+        Args:
+            snapshot_path: Path to monolithic snapshot file
+            target_dir: Directory where individual files will be written
+
+        Raises:
+            FileNotFoundError: If snapshot file doesn't exist
+            ValueError: If snapshot contains no data or missing ticker column
+        """
+        if not snapshot_path.exists():
+            raise FileNotFoundError(f"Snapshot file not found: {snapshot_path}")
+
+        logger.info(f"Restoring snapshot from {snapshot_path}")
+
+        # Read snapshot
+        snapshot_data = pl.read_parquet(snapshot_path)
+
+        if snapshot_data.is_empty():
+            raise ValueError("Snapshot contains no data")
+
+        if "ticker" not in snapshot_data.columns:
+            raise ValueError("Snapshot missing 'ticker' column")
+
+        # Ensure target directory exists
+        target_dir = Path(target_dir)
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        # Get unique tickers
+        tickers = snapshot_data.select("ticker").unique().to_series().to_list()
+        logger.info(f"Restoring {len(tickers)} tickers to {target_dir}")
+
+        # Iterate and write individual files
+        for ticker in tickers:
+            ticker_df = snapshot_data.filter(pl.col("ticker") == ticker)
+            ticker_path = target_dir / f"{ticker}.parquet"
+
+            ticker_df.write_parquet(ticker_path, compression="zstd")
+            logger.debug(f"Restored {ticker}: {len(ticker_df)} rows -> {ticker_path}")
+
+        logger.success(f"Restored {len(tickers)} ticker files to {target_dir}")
+
+    def list_snapshots(self, data_type: str | None = None) -> list[Path]:
+        """List available snapshots in archive directory.
+
+        Args:
+            data_type: Filter by data type ("prices" or "fundamentals"), or None for all
+
+        Returns:
+            List of snapshot file paths, sorted by date (newest first)
+        """
+        if data_type:
+            pattern = f"{data_type}_snapshot_*.parquet"
+        else:
+            pattern = "*_snapshot_*.parquet"
+
+        snapshots = sorted(self.archive_dir.glob(pattern), reverse=True)
+        logger.debug(f"Found {len(snapshots)} snapshots matching '{pattern}'")
+
+        return snapshots

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,0 +1,78 @@
+"""Test for restore functionality - can be run in debug mode."""
+
+from pathlib import Path
+
+import polars as pl
+from loguru import logger
+
+from src.config.settings import load_config
+from src.data_mgmt.archiver import DataArchiver
+
+
+def test_high_level_restore() -> None:
+    """Test high-level restore: restore latest snapshots to test directory.
+
+    Equivalent to: uv run qc restore --target-dir data/test
+    """
+    # Load config
+    config = load_config()
+
+    # Initialize archiver
+    archiver = DataArchiver(config.settings.base_dir, config.settings.archive_dir)
+
+    # Define target base directory
+    target_base = Path("data/test")
+
+    # Restore prices
+    logger.info("Restoring latest prices snapshot")
+    price_snapshots = archiver.list_snapshots("prices")
+    if price_snapshots:
+        latest_prices = price_snapshots[0]
+        target_prices = target_base / "prices"
+        logger.info(f"Restoring prices from {latest_prices.name}")
+        archiver.restore_snapshot(latest_prices, target_prices)
+        logger.success(f"✅ Prices restored to {target_prices}")
+    else:
+        logger.warning("No prices snapshots found")
+
+    # Restore fundamentals
+    logger.info("Restoring latest fundamentals snapshot")
+    fund_snapshots = archiver.list_snapshots("fundamentals")
+    if fund_snapshots:
+        latest_fund = fund_snapshots[0]
+        target_fund = target_base / "fundamentals"
+        logger.info(f"Restoring fundamentals from {latest_fund.name}")
+        archiver.restore_snapshot(latest_fund, target_fund)
+        logger.success(f"✅ Fundamentals restored to {target_fund}")
+    else:
+        logger.warning("No fundamentals snapshots found")
+
+    logger.success(f"✅ All snapshots restored to {target_base}")
+
+    # Read and verify restored price data for SU.PA and MSFT
+    logger.info("Reading restored price data for SU.PA and MSFT")
+
+    prices_dir = target_base / "prices"
+    tickers: list[str] = ["SU.PA", "MSFT"]
+
+    for ticker in tickers:
+        ticker_path = prices_dir / f"{ticker}.parquet"
+        if ticker_path.exists():
+            df_test = pl.read_parquet(ticker_path)
+            row_count = len(df_test)
+            date_min = str(df_test["date"].min())
+            date_max = str(df_test["date"].max())
+            columns = list(df_test.columns)
+
+            logger.info(f"{ticker}: {row_count:,} rows")
+            logger.info(f"Date range: {date_min} to {date_max}")
+            logger.info(f"Columns: {columns!r}")
+            print(f"\n{ticker} sample:")
+            print(df_test.head())
+        else:
+            logger.warning(f"{ticker} data not found at {ticker_path}")
+
+
+if __name__ == "__main__":
+    # Run the restore test for debugging
+    test_high_level_restore()

--- a/uv.lock
+++ b/uv.lock
@@ -1264,6 +1264,7 @@ dependencies = [
     { name = "plotly" },
     { name = "polars" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "streamlit" },
     { name = "yfinance" },
 ]
@@ -1275,6 +1276,7 @@ dev = [
     { name = "pydantic-settings" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1287,8 +1289,10 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "streamlit", specifier = ">=1.30.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "yfinance", specifier = ">=0.2.35" },
 ]
 provides-extras = ["dev"]
@@ -1547,6 +1551,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/7d/7c181feadc8941f418d0d26c3790ee34ffa4bd0a294bc5201d44ebd19c1e/tornado-6.5.3-cp39-abi3-win32.whl", hash = "sha256:88141456525fe291e47bbe1ba3ffb7982549329f09b4299a56813923af2bd197", size = 446433, upload-time = "2025-12-11T04:16:38.332Z" },
     { url = "https://files.pythonhosted.org/packages/34/98/4f7f938606e21d0baea8c6c39a7c8e95bdf8e50b0595b1bb6f0de2af7a6e/tornado-6.5.3-cp39-abi3-win_amd64.whl", hash = "sha256:ba4b513d221cc7f795a532c1e296f36bcf6a60e54b15efd3f092889458c69af1", size = 446842, upload-time = "2025-12-11T04:16:39.867Z" },
     { url = "https://files.pythonhosted.org/packages/7a/27/0e3fca4c4edf33fb6ee079e784c63961cd816971a45e5e4cacebe794158d/tornado-6.5.3-cp39-abi3-win_arm64.whl", hash = "sha256:278c54d262911365075dd45e0b6314308c74badd6ff9a54490e7daccdd5ed0ea", size = 445863, upload-time = "2025-12-11T04:16:41.099Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Implement `DataArchiver` for compressed parquet snapshots (prices/fundamentals).
- Optimize storage using `Categorical` types for low-cardinality columns.
- Centralize ticker configuration in `config.yaml`.
- Refactor `main.py` CLI to support `etl`, `snapshot`, and `restore` commands.
- Add high-level restore logic to auto-recover latest backups.