### PR TITLE
Merge: Architecture documentation, Makefile improvements, and portfolio filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,10 @@ get-context:
 	@echo "✅ Project context ($(CONTEXT_DOCS)) copied to clipboard."
 
 project-export:
-	@gh project item-list 1 --owner timzen6 --format json > llm_inputs/project_items.json
+	@mkdir -p llm_inputs
+	@gh project item-list 1 --owner timzen6 --format json | jq '[.items[] | {number: .content.number, title: .title, status: .status, body: .content.body}]' > llm_inputs/project_items.json
 	@cat llm_inputs/project_items.json | pbcopy
-	@echo "✅ Project items exported to llm_inputs/project_items.json and copied to clipboard"
+	@echo "✅ LLM-optimized project items exported to llm_inputs/project_items.json and copied to clipboard"
 
 pr-diff: pc
 	@mkdir -p llm_inputs

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -348,6 +348,7 @@ universe:
     - EURJPY=X
     - EURDKK=X
     - EURSEK=X
+    - EURNOK=X
     - EURCAD=X
     # Bond Yields
     - ^TNX      # US 10 Year Treasury

--- a/docs/polars_metrics_engine.md
+++ b/docs/polars_metrics_engine.md
@@ -1,0 +1,305 @@
+# Polars Metrics Engine — Patterns & Learnings
+
+Learnings from building a financial metrics calculation pipeline in Polars. Covers patterns for time series enrichment, TTM calculations, multi-currency handling, and where Polars gives practical advantages over Pandas.
+
+---
+
+## The General Idea
+
+Financial data arrives as two separate time series — **daily prices** and **periodic fundamentals** (annual/quarterly reports). The core challenge is combining them into a single enriched dataset where every price row carries its most recent fundamental context.
+
+The engine follows a three-stage pipeline:
+
+```
+Raw Fundamentals  →  Calculated Ratios  →  Merged onto Price History
+  (long-format)      (ROCE, FCF, etc.)     (via asof join)
+```
+
+This happens once at load time (cached), not at render time. The Streamlit app only reads the enriched result.
+
+---
+
+## Architecture: Engine Classes
+
+The calculation logic is split into specialized engines, each owning one concern:
+
+| Engine | Responsibility | Key Pattern |
+|---|---|---|
+| `TTMEngine` | Roll quarterly data into trailing-12-month figures | Rolling window aggregation |
+| `MetricsEngine` | Calculate fundamental ratios + merge onto prices | Expression lists, `join_asof` |
+| `FXEngine` | Currency conversion using historical rates | Split-process-concat |
+| `PortfolioEngine` | Portfolio value history from positions × prices | Cumulative sums, `join_asof` |
+| `StrategyEngine` | Factor scoring per stock | Pydantic models, weighted expressions |
+
+Each engine is a plain Python class with no Streamlit dependency — instantiated in the logic layer, results consumed by views.
+
+---
+
+## Polars Patterns
+
+### 1: Expression Lists
+
+The most distinctive Polars pattern in this project. Instead of calculating metrics one by one (mutating the DataFrame repeatedly), build a list of expressions and apply them in a single `.with_columns()`:
+
+```python
+exprs = []
+
+# Each expression is self-contained
+exprs.append((pl.col("total_assets") - pl.col("total_current_liabilities")).alias("capital_employed"))
+exprs.append((pl.col("ebit") / capital_employed_expr).alias("roce"))
+exprs.append((pl.col("gross_profit") / pl.col("revenue")).alias("gross_margin"))
+exprs.append((pl.col("ebit") / pl.col("revenue")).alias("ebit_margin"))
+
+df = df.with_columns(exprs)
+```
+
+**Why it works well:**
+- All expressions run in a single pass — Polars parallelizes them internally.
+- Easy to extend: adding a new metric is one `append` line.
+- Readable: each expression is named and self-contained.
+- Expressions can reference each other within the same batch if defined carefully (or chain multiple `.with_columns()` calls when there are dependencies).
+
+**Pandas equivalent would be:** Repeated `df["new_col"] = df["a"] / df["b"]` mutations, or a messy `.assign()` chain. No parallelization.
+
+---
+
+### 2: `pl.coalesce` for Fallback Chains
+
+Financial data is messy. A field might exist in one source but not another. `coalesce` picks the first non-null value — like SQL `COALESCE`:
+
+```python
+# Prefer TTM EPS, fall back to annual
+eps = pl.coalesce(pl.col("eps_ttm"), pl.col("eps_annual"))
+
+# Prefer diluted shares, fall back to basic
+shares = pl.coalesce(
+    pl.col("diluted_average_shares"),
+    pl.col("basic_average_shares"),
+)
+
+# Debt: use total if available, otherwise reconstruct
+debt = pl.coalesce(
+    pl.col("total_debt"),
+    pl.col("long_term_debt").fill_null(0) + pl.col("short_term_debt").fill_null(0),
+)
+```
+
+This pattern appears everywhere in the metrics engine. It keeps the code declarative — you state *what you prefer*, not *how to check* for nulls.
+
+**Pandas equivalent:** Nested `np.where` or chained `.fillna()` calls. Much noisier.
+
+---
+
+### 3: `join_asof` — The Financial Time Series Join
+
+The most important join in the project. Prices are daily, fundamentals are quarterly/annual. `join_asof` with `strategy="backward"` maps each price row to the most recent available fundamental report:
+
+```python
+df_prices = df_prices.join_asof(
+    df_annual,
+    left_on="date",
+    right_on="report_date",
+    by="ticker",
+    strategy="backward",
+)
+```
+
+This means: for each `(ticker, date)` in prices, find the most recent `report_date ≤ date` in fundamentals and attach that row.
+
+**Used for:**
+- Mapping annual/TTM EPS onto daily prices → P/E ratio history.
+- Mapping FX rates onto asset prices → currency conversion.
+- Mapping transactions onto trading days → portfolio positions.
+
+**Pandas equivalent:** Manual `pd.merge_asof` — similar API, but Polars is significantly faster on large datasets and handles the `by` grouping more naturally.
+
+---
+
+### 4: TTM via Rolling Windows
+
+Trailing Twelve Months is the standard for fresh valuations. The engine uses Polars' `.rolling()` with a date-based window:
+
+```python
+df_ttm = (
+    df_quarterly
+    .sort(["ticker", "report_date"])
+    .rolling(
+        index_column="report_date",
+        period="395d",          # ~13 months: safely captures 4 quarters
+        group_by="ticker",
+        closed="right",
+    )
+    .agg([
+        # Flow metrics (P&L, Cash Flow): sum of last 4 quarters
+        pl.col("revenue").tail(4).sum().alias("revenue_ttm"),
+        pl.col("free_cash_flow").tail(4).sum().alias("fcf_ttm"),
+        # Point metrics (Balance Sheet): latest snapshot
+        pl.col("total_debt").last().alias("total_debt_ttm"),
+        # Quality gate
+        pl.len().alias("_record_count"),
+    ])
+    .filter(pl.col("_record_count") >= 4)  # Only emit when we have a full year
+)
+```
+
+**Key decisions:**
+- **395 days**, not 365: reporting dates shift slightly between quarters. The extra buffer prevents data loss.
+- **`tail(4).sum()`** instead of just `.sum()`: ensures we only sum the 4 most recent quarters within the window, not accidental extras.
+- **`_record_count >= 4`** quality gate: prevents publishing TTM from 2 quarters (which would understate revenue and overstate valuations).
+- **Flow vs. Point distinction**: Revenue gets summed (it accumulates). Debt gets `.last()` (it's a snapshot).
+
+**This would be painful in Pandas.** `pd.DataFrame.rolling()` doesn't support grouped date-based windows natively. You'd need `groupby().apply()` with a custom function — slow and verbose.
+
+---
+
+### 5: Hybrid Merge (TTM + Annual Fallback)
+
+Not every ticker has quarterly data. The engine merges both sources onto prices, then uses `coalesce` to prefer TTM where available:
+
+```
+Prices  ←asof join←  Annual fundamentals  (always available)
+        ←asof join←  TTM fundamentals     (when quarterly data exists)
+```
+
+```python
+# After both joins:
+eps = pl.coalesce(pl.col("eps_ttm"), pl.col("eps_annual"))
+pe_ratio = pl.col("close") / eps
+
+# Track which source was used
+pl.when(pl.col("eps_ttm").is_not_null())
+  .then(pl.lit("TTM"))
+  .when(pl.col("eps_annual").is_not_null())
+  .then(pl.lit("Annual"))
+  .otherwise(pl.lit("N/A"))
+  .alias("valuation_source")
+```
+
+The `valuation_source` column is surfaced in the UI so the user knows whether they're looking at fresh TTM or older annual data.
+
+---
+
+### 6: `_ensure_schema` — Defensive Column Handling
+
+Data providers change schemas. A column that existed last quarter might disappear. Instead of crashing, the engine fills missing columns with typed nulls:
+
+```python
+def _ensure_schema(self, df: pl.DataFrame, required_cols: list[str]) -> pl.DataFrame:
+    existing = set(df.columns)
+    missing = [c for c in required_cols if c not in existing]
+    if missing:
+        exprs = [pl.lit(None).cast(inferred_type).alias(c) for c in missing]
+        df = df.with_columns(exprs)
+    return df
+```
+
+Called before every major calculation step. This means downstream expressions can always reference the expected columns — they'll just be null if the data wasn't there. `coalesce` then handles the fallback.
+
+---
+
+### 7: `pipe()` for Composable Transformations
+
+Instead of deeply nested function calls, chain transformations with `.pipe()`:
+
+```python
+df_prices_latest = (
+    df_prices
+    .filter(pl.col("ticker").is_in(selected_tickers))
+    .pipe(fx_engine.convert_multiple_to_target, amount_cols=["close", "fair_value"], source_currency_col="currency")
+    .sort(["ticker", "date"])
+    .group_by("ticker")
+    .agg(...)
+)
+```
+
+`.pipe()` lets you insert a multi-argument function (like FX conversion) into a method chain without breaking the flow. The DataFrame is passed as the first argument.
+
+---
+
+### 8: Split-Process-Concat for Multi-Currency Data
+
+The FX engine can't apply a single rate to all rows (different currencies need different rates). Solution: split into groups, process each, recombine:
+
+```python
+# Home currency rows: no conversion needed
+df_home = df.filter(pl.col("currency") == "EUR")
+
+# Foreign currency rows: join FX rate, then multiply
+for currency, rate_df in self.fx_rates.items():
+    df_chunk = df.filter(pl.col("currency") == currency)
+    df_chunk = df_chunk.join_asof(rate_df, on="date", strategy="backward")
+    chunks.append(df_chunk.with_columns(pl.col(amount_col) / pl.col("rate")))
+
+df_result = pl.concat([df_home, *chunks], how="vertical_relaxed")
+```
+
+`how="vertical_relaxed"` handles slight schema differences between chunks (e.g., one chunk might not have a `rate` column).
+
+---
+
+### 9: Aggregation with Embedded Lists
+
+For the screener's sparkline columns, Polars' native `List` type stores 30 data points in a single cell:
+
+```python
+.group_by("ticker").agg(
+    pl.last("close_EUR").alias("close"),
+    pl.tail("close_EUR", 30).alias("close_30d"),  # List[Float64] in one cell
+    pl.col("pe_ratio").quantile(0.25).alias("pe_p25"),
+)
+```
+
+The view layer reads `close_30d` directly as a list and renders an inline sparkline. No second query, no separate DataFrame.
+
+---
+
+## Where Polars Shines Over Pandas (In This Project)
+
+| Area | Polars Advantage | Pandas Pain |
+|---|---|---|
+| **`join_asof` with grouping** | Native `by="ticker"` + `strategy="backward"` in one call | `merge_asof` exists but is slower, grouping less ergonomic |
+| **Rolling windows by date + group** | `.rolling(index_column=, group_by=)` in one pass | `groupby().apply()` + custom rolling — slow, verbose |
+| **Expression parallelism** | 15 expressions in one `.with_columns()` run in parallel | Sequential `df["col"] = ...` mutations |
+| **`coalesce`** | Clean declarative fallback chains | Nested `.fillna()` or `np.where` |
+| **Null handling** | First-class null propagation through expressions | `NaN` vs `None` confusion, `fillna` vs `replace` |
+| **Type safety** | Schema errors caught at expression build time | Runtime `KeyError` or silent dtype coercion |
+| **`vertical_relaxed` concat** | Schema evolution handled gracefully | `pd.concat` requires matching columns or throws |
+| **List columns** | Native `List[Float64]` type for sparklines | Requires storing as object dtype (slow, untyped) |
+
+The strongest practical win is the **expression model**. Building a list of 15 metric calculations and applying them in one `.with_columns()` is cleaner and faster than any Pandas approach. For time series work with irregular joins, `join_asof` and date-based `.rolling()` are category advantages.
+
+---
+
+## Domain-Specific Insights
+
+**Data quality is the real engineering problem.** The metrics engine spends ~40% of its code handling missing data, schema drift, and source-specific quirks (LSE pence-to-pounds conversion, EPS fallback chains). The actual ratio math is trivial.
+
+**The TTM engine is the highest-value component.** Annual data can be 6–12 months stale. TTM keeps valuations current. The `flow_metrics` vs. `point_metrics` distinction (sum vs. last) is critical to get right — summing balance sheet items is a common bug.
+
+**`data_lag_days` is a key UX insight.** Every enriched price row carries `(date - metric_date).dt.total_days()` — the staleness of its fundamental data. This is surfaced as a colored column in the screener so users immediately see which tickers have fresh data and which are coasting on old reports.
+
+**The `_pound_fix` is a real-world wart.** London Stock Exchange prices come in pence, not pounds. A conditional `pl.when().then()` expression fixes this at the boundary. Domain-specific edge cases like this are inevitable — handle them early and document why.
+
+**Coalescing and fallback chains are the unsung hero.** Financial quantities often have multiple computation routes (e.g., EPS from the API vs. derived from net income / shares). `pl.coalesce` plus windowed aggregations make it natural to define a preference order without nested if-else logic. Combined with `_ensure_schema`, this means the engine gracefully degrades when a data source changes — instead of crashing, it falls through to the next available path.
+
+---
+
+## Notes & Deferred Decisions
+
+**Expression composition via variable reuse.** When metric B depends on metric A (e.g., ROCE = EBIT / capital_employed), the cleanest Polars pattern is to define intermediate expressions as variables and compose them:
+
+```python
+capital_employed = pl.col("total_assets") - pl.col("total_current_liabilities")
+roce = pl.col("ebit") / capital_employed
+
+df = df.with_columns([
+    capital_employed.alias("capital_employed"),
+    roce.alias("roce"),
+])
+```
+
+This avoids chained `.with_columns()` calls and keeps everything in a single pass. The project uses this in some places but not consistently — worth adopting as the default style going forward.
+
+**Testing the metrics layer** is deferred. The engines are pure Polars with no Streamlit dependency, so they're straightforward to test with pytest when the time comes. No decision needed yet on fixture strategy (synthetic DataFrames vs. real Parquet snapshots).
+
+**Premature optimization is the enemy.** The TTM 395-day window, `_ensure_schema` heuristics, engine nesting, and full-pipeline enrichment on cache miss all work well at current scale. Don't optimize what isn't slow.

--- a/docs/streamlit_strategy.md
+++ b/docs/streamlit_strategy.md
@@ -1,0 +1,316 @@
+# Streamlit Application Strategy
+
+Learnings and patterns from building a Streamlit-based financial dashboard. Not exhaustive — just what we know works, captured so we don't start from zero next time.
+
+---
+
+## Part 1: General Blueprint
+
+### 1. The Core Problem with Streamlit
+
+Streamlit re-runs scripts top-to-bottom on every interaction. Without structure, this leads to:
+- Spaghetti code mixing data loading, computation, and UI in one file.
+- Redundant recomputation killing responsiveness.
+- Unmaintainable pages that grow to 500+ lines.
+
+The entire strategy below exists to **tame the re-run model**.
+
+---
+
+### 2. MVC Layering — The Non-Negotiable Foundation
+
+Split every feature across three layers:
+
+```
+src/app/
+├── pages/     # Controller — wiring only
+├── logic/     # Model — pure Python, no st.* calls
+└── views/     # View — pure rendering, no computation
+```
+
+#### Pages (Controller)
+- Max ~100 lines. If a page grows beyond that, logic or rendering leaked in.
+- Responsibilities: `set_page_config`, sidebar widgets, call logic, pass results to views, error handling.
+- Use `st.stop()` as early returns when data is missing or selections are invalid.
+
+```python
+# pages/01_overview.py — ideal shape
+st.set_page_config(page_title="Overview", layout="wide")
+
+data = load_data()
+if not data:
+    render_empty_state("No data available")
+    st.stop()
+
+selection = st.sidebar.selectbox("Pick one", options)
+result = compute_something(data, selection)   # logic call
+render_result_chart(result)                    # view call
+```
+
+#### Logic (Model)
+- **Zero** Streamlit imports. Pure Python/Polars functions.
+- Takes DataFrames or domain objects as input, returns DataFrames or dataclasses.
+- Testable in isolation — no browser needed.
+
+#### Views (Rendering)
+- **Zero** data loading or heavy computation.
+- Functions named `render_*()`, receiving prepared data.
+- All Plotly/Streamlit widget calls live here.
+
+**Why this matters:** Logic and views become independently testable. If you need to swap Plotly for Altair, only view files change. If data schema shifts, only logic files change.
+
+---
+
+### 3. The Complexity Scaler
+
+Not every feature needs a package. Scale the file structure to match complexity:
+
+| Complexity | Logic | View |
+|---|---|---|
+| **Simple** (single chart, one table) | `logic/feature.py` | `views/feature.py` |
+| **Complex** (multiple tabs, charts, tables) | `logic/feature/` package | `views/feature/` package |
+
+For packages, use `__init__.py` to expose a clean public API. Internal modules stay private.
+
+---
+
+### 4. Caching Strategy
+
+Caching is the single most impactful performance lever in Streamlit.
+
+#### Rules
+1. **Cache at the data loading boundary**, not deep inside logic.
+2. Use `@st.cache_data(ttl=<seconds>)` for DataFrames. Use `@st.cache_resource` for connections, engines, or objects that can't be serialized.
+3. **Keep cached functions as module-level free functions**, not class methods — Streamlit's cache serializes arguments, and `self` doesn't serialize cleanly.
+
+```python
+# Pattern: class delegates to a cached free function
+class DataLoader:
+    def load(self) -> DataFrame:
+        return _load_cached(self.path)
+
+@st.cache_data(ttl=3600)
+def _load_cached(path: Path) -> DataFrame:
+    return pl.scan_parquet(path / "*.parquet").collect()
+```
+
+#### Anti-Patterns
+- Caching a function that takes a mutable argument (DataFrame contents change → cache miss every time).
+- Caching fine-grained computations — overhead of hashing often exceeds the compute saved.
+- Forgetting TTL — stale data silently corrupts the UI.
+
+#### Lazy vs. Eager Polars
+Avoid premature optimization. Polars is fast enough in eager mode for dashboards of this scale. Use lazy execution (`LazyFrame`) only if profiling shows a real bottleneck — not as a default.
+
+---
+
+### 5. Data Container Pattern
+
+Avoid passing 5+ DataFrames through every function. Bundle related data into a typed container:
+
+```python
+@dataclass
+class DashboardData:
+    prices: pl.DataFrame
+    fundamentals: pl.DataFrame
+    metadata: pl.DataFrame
+```
+
+Benefits:
+- Single return value from the data loader.
+- Functions take one argument instead of many.
+- Easy to extend without breaking existing signatures.
+
+---
+
+### 6. Session State Discipline
+
+Session state is Streamlit's mutable escape hatch. Use it deliberately:
+
+| Good Use | Bad Use |
+|---|---|
+| Persisting user filter selections across re-runs | Storing computed DataFrames (use cache instead) |
+| "Reset filters" callback via `st.session_state.update(...)` | Complex state machines with many interdependent keys |
+| Tracking which items are selected in a multiselect | Anything that could be derived from widget return values |
+
+**Clear Filters pattern:**
+```python
+def clear_filters():
+    st.session_state["sector_filter"] = []
+    st.session_state["portfolio_filter"] = []
+
+st.sidebar.button("Clear Filters", on_click=clear_filters, type="primary")
+```
+
+---
+
+### 7. Fragment Pattern for Performance
+
+`@st.fragment()` lets a section re-run independently without re-running the entire page. Use it when:
+- A heavy chart section sits below light filters.
+- An interactive table shouldn't retrigger the full data pipeline on every row click.
+
+```python
+# Page-level: runs once, sets up data & sidebar
+data = load_data()
+filters = sidebar_widgets()
+
+@st.fragment()
+def render_dashboard(data, filters):
+    # Only this block re-runs on widget interaction inside it
+    chart = build_chart(data, filters)
+    st.plotly_chart(chart)
+
+render_dashboard(data, filters)
+```
+
+Place expensive data loading **above** the fragment. Lightweight rendering **inside** it.
+
+**Note:** As the app grows, widget `key` collisions across fragments and pages can become a problem. No formal naming convention needed yet, but be aware of it.
+
+---
+
+### 8. Visual Consistency System
+
+Define visual constants once. Reference everywhere.
+
+#### Color Palette
+Create a `Colors` class or module with named constants:
+```python
+class Colors:
+    blue = "#2563eb"
+    green = "#059669"
+    red = "#dc2626"
+    amber = "#d97706"
+
+COLOR_SCALE_GREEN_RED = [Colors.green, Colors.light_green, Colors.yellow, Colors.light_red, Colors.red]
+COLOR_SCALE_CONTRAST = [Colors.blue, Colors.orange, Colors.teal, Colors.purple, ...]
+```
+
+Use semantic scales (`GREEN_RED` for good/bad values) and categorical scales (`CONTRAST` for sectors, tickers).
+
+**Lesson learned:** Pure yellow (`#FF0`) is invisible on white backgrounds. Use amber/gold instead.
+
+#### Plotly Defaults
+Standardize chart appearance:
+- `template="plotly_white"` as the base.
+- Remove redundant axis titles — if the chart title says "Revenue Growth", the y-axis doesn't need to repeat it.
+- Consistent `height`, `margin`, and `legend` positioning.
+
+#### Mapping Constants
+Centralize emoji/icon mappings (sector → emoji, country → flag) in a `constants.py` file. Keeps views clean and mapping updates to one place.
+
+---
+
+### 9. Shared Components
+
+Build a `views/common.py` for widgets that appear on multiple pages:
+
+- **KPI cards** — `render_kpi_cards(metrics)` using `st.columns` + `st.metric`.
+- **Empty states** — `render_empty_state(message, icon)` with a consistent look.
+- **Sidebar header** — `render_sidebar_header(title, subtitle)` for brand consistency.
+- **Selection widgets** — Portfolio/ticker selectors that encapsulate options logic.
+
+These should be **thin wrappers** — if a component grows beyond ~40 lines, it probably belongs in its own file.
+
+---
+
+### 10. Error Handling — Keep It Simple
+
+For local/private-use dashboards, let errors propagate naturally. Wrapping everything in broad `try/except` blocks adds unnecessary layers and hides the actual problem.
+
+**Preferred approach:**
+- Handle errors **locally** where it matters: if data for a specific chart is missing, skip that chart or show an empty state — don't crash the whole page.
+- Let unexpected errors bubble up with a full traceback. During development, a visible traceback is more useful than a generic `st.error()` message.
+- Use `st.stop()` for early exits when a required selection is missing (not as error handling, but as flow control).
+- Use `loguru` for structured logging when debugging is needed.
+
+```python
+# Flow control — not error handling
+if selected_portfolio is None:
+    render_empty_state("Select a portfolio to continue")
+    st.stop()
+
+# Local graceful degradation
+if df_chart_data.is_empty():
+    st.info("No data available for this selection.")
+else:
+    render_chart(df_chart_data)
+```
+
+**Anti-pattern:** A big `try/except Exception` around the entire page that swallows all errors into `st.error()`. This makes debugging harder, not easier.
+
+---
+
+### 11. Project Configuration
+
+#### Config File Strategy
+- Use YAML for user-facing configuration (portfolios, watchlists, tickers).
+- Validate with **Pydantic models** on load — fail fast with clear error messages.
+- Use `pathlib.Path` throughout. Never `os.path.join`.
+
+#### Entry Point
+```bash
+streamlit run src/app/main.py
+```
+Use a `Makefile` or similar for the launch command so nobody needs to remember the path.
+
+---
+
+### 12. File I/O Hygiene
+
+For any app that writes data (ETL pipelines, user exports):
+- **Atomic writes**: Write to `.tmp`, then rename. Prevents corruption on crash.
+- **Parquet over CSV**: Type-safe, smaller, faster reads with Polars `scan_parquet`.
+- Separate **data production** (ETL) from **data consumption** (Streamlit app). The app should never call external APIs directly.
+
+---
+
+### 13. Multi-Page App Structure
+
+Streamlit's built-in multi-page system uses filename prefixes for ordering:
+
+```
+pages/
+├── 01_Overview.py
+├── 02_Asset_Detail.py
+├── 03_Stock_Screener.py
+└── 09_Admin.py
+```
+
+- Number prefixes control sidebar order.
+- Each page calls `st.set_page_config()` at the top.
+- Skip numbers (01, 02, 03, 09) to leave room for insertion.
+- A `00_Startpage.py` or `main.py` serves as the landing page.
+
+---
+
+### 14. Testing Approach
+
+For a project of this scope, comprehensive UI testing is overkill. The MVC pattern is the important part — it *enables* testing later without requiring it now.
+
+- **Logic layer**: Testable with standard pytest — pure functions in, DataFrames out, no Streamlit dependency. This is where testing effort should go first when the time comes.
+- **Views/Pages**: Visual QA for now. The MVC split means we can add `AppTest`-based integration tests later without restructuring.
+
+---
+
+## Part 2: Domain-Specific Learnings (Financial Dashboard)
+
+### Data Model Choices
+- **Long-format fundamentals** (`[date, metric, value, period]`) simplify aggregation (TTM calculations, metric pivoting) compared to wide tables.
+- **Prices and fundamentals in separate Parquet stores**, partitioned by ticker. Keeps reads fast and schema evolution clean.
+- Use a `MetricsEngine` to derive computed fields (P/E, ROCE, FCF Yield) at load time, not at render time.
+
+### Financial UI Patterns
+- **Strategy Factor Profiles**: Grouped bar charts comparing a stock's factor scores to sector reference values. Gives users immediate visual context.
+- **Conditional table styling**: Color-code P/E ratios (green → red), ROCE (red → green), and data lag (fresh → stale). Maps readability to domain semantics.
+- **Sparkline columns**: Inline 30-day price charts in the screener table for at-a-glance trend assessment.
+- **Portfolio composition**: Sunburst charts for hierarchical breakdowns (Asset Class → Factor → Position).
+
+### FX Handling
+- A dedicated `FXEngine` converts all values to a target currency (EUR) using price data that's already in the local data lake.
+- FX conversion happens in the logic layer, not in views.
+
+### Portfolio Abstraction
+- Portfolio types (`absolute`, `transactional`, `watchlist`) drive different calculation paths.
+- Config-driven: portfolios defined in YAML, validated by Pydantic, consumed by portfolio engines. Adding a portfolio requires zero code changes.

--- a/src/app/00_Startpage.py
+++ b/src/app/00_Startpage.py
@@ -73,7 +73,7 @@ else:
     relevant_portfolios = {
         k: v
         for k, v in portfolios_config.items()
-        if (v is not None) and (v.type == PortfolioType.ABSOLUTE)
+        if (v is not None) and (v.type in (PortfolioType.ABSOLUTE, PortfolioType.TRANSACTIONAL))
     }
 df_portfolio = calculate_multiple_portfolio_metrics(
     data,


### PR DESCRIPTION
**Description:**
This merge brings in crucial architectural documentation and minor system improvements:

* **Documentation:** Added `polars_metrics_engine.md` and `streamlit_strategy.md` to capture our core patterns (MVC separation in Streamlit, Polars expression lists, and caching strategies). These are excellent blueprints for maintaining high-quality standards in our educational codebase.
* **App Logic:** Updated `00_Startpage.py` to properly include `PortfolioType.TRANSACTIONAL` alongside absolute portfolios for the overview generation.
* **Config:** Added the `EURNOK=X` currency pair to the universe configuration.
* **Tooling:** Improved the `Makefile` project export command by utilizing `jq` to parse and format LLM-optimized project items, and safely wrapped the output directory creation with `mkdir -p`.
